### PR TITLE
make behaviour on missing step implementation configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ You'll need to require SimpleBDD in the spec helper and include it into your tes
   	  config.include SimpleBdd
 	end
 
+By default, SimpleBDD marks specs pending on missing step implementations.
+You can change this behavior to raise an error instead in the spec helper:
+
+        RSpec.configure do |config|
+          config.raise_error_on_missing_step_implementation = true
+        end
+
 ## Contributing
 
 1. Fork it

--- a/lib/simple_bdd.rb
+++ b/lib/simple_bdd.rb
@@ -1,13 +1,22 @@
 require "simple_bdd/version"
 
 module SimpleBdd
+  class StepNotImplemented < StandardError; end
+
+  RSpec.configuration.add_setting(:raise_error_on_missing_step_implementation,
+                                  default: false) if defined?(::RSpec)
+
   %w[Given When Then And Also But].each do |method|
     define_method(method) do |message|
       method_name = methodize(message)
       if respond_to? method_name || !defined?(::RSpec)
         send method_name
       else
-        pending(method_name)
+        if RSpec.configuration.raise_error_on_missing_step_implementation?
+          raise StepNotImplemented, method_name
+        else
+          pending(method_name)
+        end
       end
     end
 

--- a/spec/pending_feature_spec.rb
+++ b/spec/pending_feature_spec.rb
@@ -12,9 +12,37 @@ describe "Pending features in rspec" do
 
   subject { SimpleBddExample.new }
 
-  it "should make the step pending" do
-    subject.should_receive(:pending).with("i_have_not_defined_a_step")
-    subject.Given "I have not defined a step"
+  context "when raise_error_on_missing_step_implementation is true" do
+    before(:each) do
+      @raise_error = RSpec.configuration.raise_error_on_missing_step_implementation
+      RSpec.configuration.raise_error_on_missing_step_implementation = true
+    end
+
+    it "raises an error on missing step implementations" do
+      expect {
+        subject.Given "I have not defined a step"
+      }.to raise_error SimpleBdd::StepNotImplemented
+    end
+
+    after(:each) do
+      RSpec.configuration.raise_error_on_missing_step_implementation = @raise_error
+    end
+  end
+
+  context "when raise_error_on_missing_step_implementation is false" do
+    before(:each) do
+      @raise_error = RSpec.configuration.raise_error_on_missing_step_implementation
+      RSpec.configuration.raise_error_on_missing_step_implementation = false
+    end
+
+    it "makes the step pending" do
+      subject.should_receive(:pending).with("i_have_not_defined_a_step")
+      expect { subject.Given "I have not defined a step" }.to_not raise_error
+    end
+
+    after(:each) do
+      RSpec.configuration.raise_error_on_missing_step_implementation = @raise_error
+    end
   end
 
   it "should still raise NoMethodError in code under test" do


### PR DESCRIPTION
As discussed in #11, what do you think?

Introduces RSpec option raise_error_on_missing_step_implementation,
which is false by default. If true, a custom error will be raised when a
step implementation is missing, otherwise the spec will be marked pending.
