### PR TITLE
Add simple_bdd/rspec shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,13 @@ Any of the following names can be substituted for `behavior` above:
 
 ## RSpec
 
-You'll need to require SimpleBDD in the spec helper and include it into your tests like so:
+To use SimpleBDD in your tests, simply add the following line to your spec helper:
+
+``` ruby
+require 'simple_bdd/rspec'
+```
+
+Or, if you want to have more control, you can do this instead:
 
 ``` ruby
 require 'simple_bdd'

--- a/lib/simple_bdd/rspec.rb
+++ b/lib/simple_bdd/rspec.rb
@@ -1,0 +1,5 @@
+require 'simple_bdd'
+
+RSpec.configure do |config|
+  config.include SimpleBdd
+end

--- a/spec/rspec_spec.rb
+++ b/spec/rspec_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'simple_bdd/rspec' do
+  it 'includes SimpleBdd in RSpec' do
+    Given 'some state'
+    When 'this happens'
+    Then 'this change occurs'
+  end
+
+  def some_state
+  end
+
+  def this_happens
+  end
+
+  def this_change_occurs
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,5 +4,5 @@ RSpec.configure do |config|
   config.filter_run :focus
   config.order = 'random'
 
-  require File.dirname(__FILE__) + '/../lib/simple_bdd'
+  require File.dirname(__FILE__) + '/../lib/simple_bdd/rspec'
 end


### PR DESCRIPTION
From now on, you can use the line below on your spec helper to automatically include SimpleBDD in RSpec:

``` ruby
require 'simple_bdd/rspec'
```

The documentation for this change is included.
