### PR TITLE
rspec 3 expects pending steps to fail

### DIFF
--- a/lib/simple_bdd.rb
+++ b/lib/simple_bdd.rb
@@ -12,11 +12,10 @@ module SimpleBdd
       if respond_to? method_name || !defined?(::RSpec)
         send method_name
       else
-        if RSpec.configuration.raise_error_on_missing_step_implementation?
-          raise StepNotImplemented, method_name
-        else
+        unless RSpec.configuration.raise_error_on_missing_step_implementation?
           pending(method_name)
         end
+        raise StepNotImplemented, method_name
       end
     end
 

--- a/spec/pending_feature_spec.rb
+++ b/spec/pending_feature_spec.rb
@@ -37,7 +37,7 @@ describe "Pending features in rspec" do
 
     it "makes the step pending" do
       subject.should_receive(:pending).with("i_have_not_defined_a_step")
-      expect { subject.Given "I have not defined a step" }.to_not raise_error
+      expect { subject.Given "I have not defined a step" }.to raise_error SimpleBdd::StepNotImplemented
     end
 
     after(:each) do


### PR DESCRIPTION
In RSpec 3, when a spec is pending and passes, it returns an error like "Expected pending 'No reason given' to fail. No Error was raised", and is treated as a failure.  When a spec is pending and fails, it behaves like a pending spec did in RSpec 2.  This pull request makes simple_bdd behave as it did in RSpec 2 by raising an error either way, and only marking the step as pending if RSpec.configuration.raise_error_on_missing_step_implementation is set to false.
